### PR TITLE
docs(sphinx): using importlib_metadata.version to get package version

### DIFF
--- a/changes/49.doc
+++ b/changes/49.doc
@@ -1,0 +1,1 @@
+Fixed issue when getting the package's version in the docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,8 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath(".."))
-import mojang
+
+import importlib_metadata
 
 # -- Project information -----------------------------------------------------
 
@@ -23,8 +24,7 @@ copyright = "2022, Lucino772"
 author = "Lucino772"
 
 # The full version, including alpha/beta/rc tags
-release = mojang.__version__
-
+release = importlib_metadata.version("pymojang")
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
# Description

Because of the way the documentation is build, the package's version is not correct. More infor [here](https://github.com/pypa/setuptools_scm/#usage-from-sphinx).

## Type of change

- :page_with_curl: Documentation (Documentation only changes)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
