### PR TITLE
docs: improve docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,49 @@
+name: Deploy docs to Github Pages
+
+on:
+  push:
+    branches: ["main"]
+
+  # Leave this for testing (TODO: remove later)
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/configure-pages@v2
+    - uses: wntrblm/nox
+      with:
+        python-versions: "3.8"
+    - name: Build Docs
+      run: |
+        nox -rs docs
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: './docs/_build/html'
+
+  deploy:
+    need: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,8 +12,18 @@ def tests(session: nox.Session):
 def docs(session: nox.Session):
     session.install("-r", "requirements/requirements-docs.txt")
     session.install(".")
-    with session.chdir("docs/"):
-        session.run("make", "html")
+
+    if "--serve" in session.posargs:
+        session.run(
+            "sphinx-autobuild",
+            "-b",
+            "html",
+            "docs/",
+            "docs/_build/html/",
+            "--open-browser",
+        )
+    else:
+        session.run("sphinx-build", "-b", "html", "docs/", "docs/_build/html/")
 
 
 @nox.session

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -3,4 +3,5 @@ sphinx==4.5.0
 sphinxext-opengraph==0.6.3
 sphinx-copybutton==0.5.0
 sphinx_issues==3.0.1
+sphinx-autobuild==2021.3.14
 furo==2022.4.7


### PR DESCRIPTION
# Description

This PR improves the documentation workflow by using `sphinx-autobuild`. It also adds a custom workflow to deploy the documentation to **Github Pages** instead of **ReadTheDocs**.

## Type of change

- :page_with_curl: Documentation (Documentation only changes)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
