### PR TITLE
fix: fixed 404 error for get_uuid & get_username

### DIFF
--- a/mojang/api/auth/models.py
+++ b/mojang/api/auth/models.py
@@ -271,7 +271,7 @@ class MojangAuthenticationApp:
 
     @overload
     def get_session(
-        self, username: str, password: str, client_token: str = None
+        self, username: str, password: str, client_token: Optional[str] = None
     ) -> MojangAuthenticatedUser:
         """Authenticate with a Mojang Account
 

--- a/mojang/api/base.py
+++ b/mojang/api/base.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import requests
 
-from ..exceptions import InvalidName
+from ..exceptions import InvalidName, MethodNotAllowed, ServerError
 from . import helpers, urls
 from .models import Cape, Skin
 from .structures import ServiceStatus, UnauthenticatedProfile
@@ -67,9 +67,14 @@ def get_uuid(username: str) -> Optional[str]:
         raise InvalidName()
 
     response = requests.get(urls.api_get_uuid(username))
-    code, data = helpers.err_check(response)
+    code, data = helpers.err_check(
+        response,
+        (405, MethodNotAllowed),
+        (500, ServerError),
+        use_defaults=False,
+    )
 
-    if code == 204:
+    if code == 404:
         return None
 
     return data["id"]
@@ -126,9 +131,15 @@ def get_username(uuid: str) -> Optional[str]:
     'Notch'
     """
     response = requests.get(urls.api_get_username(uuid))
-    code, data = helpers.err_check(response, (400, ValueError))
+    code, data = helpers.err_check(
+        response,
+        (400, ValueError),
+        (405, MethodNotAllowed),
+        (500, ServerError),
+        use_defaults=False,
+    )
 
-    if code == 204:
+    if code == 404:
         return None
 
     return data["name"]

--- a/mojang/api/models.py
+++ b/mojang/api/models.py
@@ -113,8 +113,8 @@ class Skin(_Resource):
         self,
         source: str,
         variant: str,
-        id: str = None,
-        state: str = None,
+        id: Optional[str] = None,
+        state: Optional[str] = None,
         load: bool = True,
     ) -> None:
         super().__init__(source, load=load)
@@ -158,7 +158,11 @@ class Cape(_Resource):
     """
 
     def __init__(
-        self, source: str, id: str = None, state: str = None, load: bool = True
+        self,
+        source: str,
+        id: Optional[str] = None,
+        state: Optional[str] = None,
+        load: bool = True,
     ) -> None:
         super().__init__(source, load=load)
         self.__id = id

--- a/mojang/api/session.py
+++ b/mojang/api/session.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import typing as t
 
 import jwt
 import requests
@@ -247,7 +248,9 @@ def hide_user_cape(access_token: str):
 
 
 def owns_minecraft(
-    access_token: str, verify_sig: bool = False, public_key: str = None
+    access_token: str,
+    verify_sig: bool = False,
+    public_key: t.Optional[str] = None,
 ) -> bool:
     """Returns True if the authenticated user owns minecraft
 

--- a/mojang/minecraft/slp/pre_netty/__init__.py
+++ b/mojang/minecraft/slp/pre_netty/__init__.py
@@ -8,7 +8,7 @@ from .._structures import Players, SLPResponse
 
 def ping_fe01(
     sock: socket.socket,
-    hostname: str = None,
+    hostname: Optional[str] = None,
     port: int = -1,
 ):
     if hostname is not None and len(hostname) > 0 and port > 0:


### PR DESCRIPTION
# Description

This PR fixes some some issues due to a change in the return status code for the `get_uuid` and `get_username` API. Instead of a **204** response, when a value does not exists a **404** response is returned.

## Type of change

- :cockroach: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
