### PR TITLE
fix: issue with the status code for `get_uuid` & `get_username`

### DIFF
--- a/changes/61.bugfix
+++ b/changes/61.bugfix
@@ -1,0 +1,1 @@
+Fixed issue with status code returned by the APIs used in get_uuid & get_username

--- a/mojang/api/base.py
+++ b/mojang/api/base.py
@@ -134,12 +134,10 @@ def get_username(uuid: str) -> Optional[str]:
     code, data = helpers.err_check(
         response,
         (400, ValueError),
-        (405, MethodNotAllowed),
-        (500, ServerError),
-        use_defaults=False,
+        use_defaults=True,
     )
 
-    if code == 404:
+    if code == 204:
         return None
 
     return data["name"]

--- a/mojang/api/base.py
+++ b/mojang/api/base.py
@@ -69,12 +69,10 @@ def get_uuid(username: str) -> Optional[str]:
     response = requests.get(urls.api_get_uuid(username))
     code, data = helpers.err_check(
         response,
-        (405, MethodNotAllowed),
-        (500, ServerError),
-        use_defaults=False,
+        use_defaults=True,
     )
 
-    if code == 404:
+    if code == 204:
         return None
 
     return data["id"]


### PR DESCRIPTION
# Description

This **PR** fixes some issues with the **status code** returned by the APIs for the `get_uuid` and `get_username` functions. Instead of returning **404** when value does not exists, the APIs returns **204**.

## Type of change

- :cockroach: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
