### PR TITLE
fix: fixing issue with NotFound errors in `get_username` & `get_uuid`

### DIFF
--- a/changes/66.bugfix
+++ b/changes/66.bugfix
@@ -1,0 +1,1 @@
+fixing issue with NotFound errors in get_username & get_uuid

--- a/mojang/api/base.py
+++ b/mojang/api/base.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import requests
 
-from ..exceptions import InvalidName, MethodNotAllowed, ServerError
+from ..exceptions import InvalidName, NotFound
 from . import helpers, urls
 from .models import Cape, Skin
 from .structures import ServiceStatus, UnauthenticatedProfile
@@ -67,10 +67,13 @@ def get_uuid(username: str) -> Optional[str]:
         raise InvalidName()
 
     response = requests.get(urls.api_get_uuid(username))
-    code, data = helpers.err_check(
-        response,
-        use_defaults=True,
-    )
+    try:
+        code, data = helpers.err_check(
+            response,
+            use_defaults=True,
+        )
+    except NotFound:
+        return None
 
     if code == 204:
         return None
@@ -129,11 +132,14 @@ def get_username(uuid: str) -> Optional[str]:
     'Notch'
     """
     response = requests.get(urls.api_get_username(uuid))
-    code, data = helpers.err_check(
-        response,
-        (400, ValueError),
-        use_defaults=True,
-    )
+    try:
+        code, data = helpers.err_check(
+            response,
+            (400, ValueError),
+            use_defaults=True,
+        )
+    except NotFound:
+        return None
 
     if code == 204:
         return None


### PR DESCRIPTION
# Description

Due to a change in the API, `get_username` & `get_uuid` now returns a **404** when the username or uuid does not exists

## Type of change

- :cockroach: Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
